### PR TITLE
AddGHC 9.2.4.

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -43,6 +43,11 @@ jobs:
             compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
+          - compiler: ghc-9.2.4
+            compilerKind: ghc
+            compilerVersion: 9.2.4
+            setup-method: ghcup
+            allow-failure: false
       fail-fast: false
     steps:
       - name: apt

--- a/templatise.cabal
+++ b/templatise.cabal
@@ -18,7 +18,13 @@ description:
 
 category:           VSCode
 tested-with:
-  GHC ==9.2.8 || ==9.4.5 || ==9.4.6 || ==9.4.7 || ==9.6.2 || ==9.6.3
+  GHC ==9.2.4
+   || ==9.2.8
+   || ==9.4.5
+   || ==9.4.6
+   || ==9.4.7
+   || ==9.6.2
+   || ==9.6.3
 
 extra-source-files:
   CHANGELOG.md
@@ -37,13 +43,13 @@ source-repository head
 common initialise-common
   build-depends:
     , base                  ^>=4.16.3.0 || ^>=4.17.0.0 || ^>=4.18.0.0
-    , bytestring            ^>=0.11.4.0 || ^>=0.12.0.2
+    , bytestring            ^>=0.11.3.1 || ^>=0.12.0.2
     , Cabal-syntax          ^>=3.8.1.0  || ^>=3.10.1.0
     , filepath              ^>=1.4.2.2
     , mtl                   ^>=2.2.2    || ^>=2.3.1
     , network-uri           ^>=2.6.4.1  || ^>=2.7.0.0
     , optparse-applicative  ^>=0.18.1.0
-    , process               ^>=1.6.16.0
+    , process               ^>=1.6.13.2
     , text                  ^>=1.2.5.0  || ^>=2.0.2
 
 library initialise-library


### PR DESCRIPTION
This ensure compatibility with the version of GHC used in hackage's verification tests.