### PR TITLE
Switch to pre-commit's haskell environment.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,7 @@
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
-    "ghcr.io/devcontainers-contrib/features/haskell:2": {
-      "globalPackages": "cabal-fmt haskell-ci hlint ormolu"
-    },
+    "ghcr.io/devcontainers-contrib/features/haskell:2": {},
     "ghcr.io/devcontainers-contrib/features/pre-commit:2": {},
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
     - uses: haskell-actions/setup@v2
-    - uses: haskell-actions/hlint-setup@v2
-    - name: install haskell tools
-      run: cabal install --independent-goals --allow-newer cabal-fmt haskell-ci ormolu
+      with:
+        ghc-version: '9.4.7'
     - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,13 +19,17 @@ repos:
       - id: haskell-ci regenerate
         name: haskell-ci regenerate
         entry: haskell-ci regenerate
-        language: system
+        language: haskell
+        additional_dependencies:
+          - haskell-ci
         files: '(^.github/workflows/haskell-ci.yml$)|(\.cabal$)'
         pass_filenames: false
       - id: hlint
         name: hlint
         entry: hlint
-        language: system
+        language: haskell
+        additional_dependencies:
+          - hlint
         types_or: ["haskell", "literate-haskell"]
       - id: cabal check
         name: cabal check
@@ -36,13 +40,17 @@ repos:
       - id: ormolu
         name: ormolu
         entry: ormolu
-        language: system
+        language: haskell
+        additional_dependencies:
+          - ormolu
         types_or: ["haskell", "literate-haskell"]
         args: ["-i", "-c"]
       - id: cabal-fmt
         name: cabal-fmt
         entry: cabal-fmt
-        language: system
+        language: haskell
+        additional_dependencies:
+          - cabal-fmt
         files: '\.cabal$'
         exclude: '\.golden\.cabal$'
         args: ["-i"]


### PR DESCRIPTION
This is sufficient for pre-commit to isolate the environments better.  We'll see if it also has an effect on the pre-commit GitHub action caching those environments at all.  Versioning of these tools needs to be figured out but could be done with pinned versions if desired.