### PR TITLE
Swap path and basename in licence replacement.

### DIFF
--- a/lib/initialise/Licence.hs
+++ b/lib/initialise/Licence.hs
@@ -17,7 +17,7 @@ replace :: FilePath -> Initialise ()
 replace p = do
   Configuration {..} <- ask
   unless (licence == Unlicense) $
-    liftIO (writeFile (p </> path) =<< contents licence)
+    liftIO (writeFile (path </> p) =<< contents licence)
 
 contents :: LicenseId -> IO ByteString
 contents l = do


### PR DESCRIPTION
This may resolve #18 but other fixes are liable to be useful before making that claim.  Thus, we'll land this and continue working improvements before closing that issue out.