### PR TITLE
Add --cabal-project option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* --cabal-name option to specify a Cabal friendly name independent from the
+  repository or other names.
 * Test GHC 9.8.2, 9.8.1, 9.6.4, 9.6.3, 9.6.1, 9.4.8, 9.4.7, 9.4.6, 9.4.4, 9.4.3,
   9.4.2, and 9.4.1
 * Add support for text-2.0.1

--- a/lib/initialise/Cabal.hs
+++ b/lib/initialise/Cabal.hs
@@ -70,7 +70,7 @@ convert' f@(Field n@(Name _ fName) ls) = do
   Configuration {..} <- asks id
   case fName of
     -- package
-    "name" -> field (encodeUtf8 name)
+    "name" -> field (encodeUtf8 cabalName)
     "version" -> field "0.1.0.0"
     "license" -> field (BS.pack $ licenseId licence)
     "copyright" -> field (BS.pack $ unwords ["(c)", show year, T.unpack author])

--- a/lib/initialise/Configuration.hs
+++ b/lib/initialise/Configuration.hs
@@ -11,7 +11,7 @@ import Control.Monad.Logger (LogLevel)
 import Control.Monad.Logger.CallStack (LogLevel (LevelWarn))
 import Data.Text (Text)
 import Data.Time.Calendar (Year)
-import Defaults (Defaults (..), dHomePage, dName)
+import Defaults (Defaults (..), dCabalName, dHomePage, dName)
 import Distribution.SPDX.LicenseId (LicenseId (Unlicense))
 import Network.URI (URI, parseURI)
 import Options.Applicative
@@ -33,6 +33,7 @@ import Options.Applicative.Builder (maybeReader)
 
 data Configuration = Configuration
   { name :: Text,
+    cabalName :: Text,
     homepage :: URI,
     author :: Text,
     maintainer :: Text,
@@ -44,7 +45,16 @@ data Configuration = Configuration
 
 parser :: Defaults -> Parser Configuration
 parser ds@(Defaults {..}) =
-  Configuration <$> name <*> homepage <*> author <*> maintainer <*> licence <*> path <*> year <*> verbosity
+  Configuration
+    <$> name
+    <*> cabalName
+    <*> homepage
+    <*> author
+    <*> maintainer
+    <*> licence
+    <*> path
+    <*> year
+    <*> verbosity
   where
     name =
       strOption
@@ -52,6 +62,13 @@ parser ds@(Defaults {..}) =
             <> help "Name of the new project."
             <> metavar "NAME"
             <> maybeDefault (dName ds)
+        )
+    cabalName =
+      strOption
+        ( long "cabal-name"
+            <> help "Name to use in cabal."
+            <> metavar "CABAL_NAME"
+            <> maybeDefault (dCabalName ds)
         )
     homepage =
       option

--- a/lib/initialise/Defaults.hs
+++ b/lib/initialise/Defaults.hs
@@ -6,6 +6,8 @@ module Defaults
     Defaults (..),
     dName,
     dHomePage,
+    dCabalName,
+    isValidPackageName,
   )
 where
 
@@ -19,6 +21,7 @@ import qualified Git (config)
 import Network.URI (URI (uriPath), parseURI)
 import System.Directory.Extra (getCurrentDirectory)
 import System.FilePath (stripExtension, takeFileName)
+import Text.Regex.TDFA ((=~))
 
 data Defaults = Defaults
   { dOrigin :: Text,
@@ -33,6 +36,11 @@ dName :: Defaults -> Maybe Text
 dName = fmap toName . dHomePage
   where
     toName = pack . takeFileName . uriPath
+
+dCabalName :: Defaults -> Maybe Text
+dCabalName ds = do
+  name <- dName ds
+  if isValidPackageName name then Just name else Nothing
 
 dHomePage :: Defaults -> Maybe URI
 dHomePage Defaults {..} =
@@ -56,3 +64,7 @@ getDefaults = do
   timezone <- getCurrentTimeZone
   (dYear, _day) <- toOrdinalDate . localDay . utcToLocalTime timezone <$> getCurrentTime
   pure Defaults {..}
+
+-- TODO move to a validators module
+isValidPackageName :: Text -> Bool
+isValidPackageName = (=~ ("^[[:digit:]]*[[:alpha:]][[:alnum:]]*(-[[:digit:]]*[[:alpha:]][[:alnum:]]*)*$" :: String))

--- a/templatise.cabal
+++ b/templatise.cabal
@@ -45,6 +45,7 @@ common initialise-common
     , network-uri           ^>=2.6.4.1  || ^>=2.7.0.0
     , optparse-applicative  ^>=0.18.1.0
     , process               ^>=1.6.13.2
+    , regex-tdfa            ^>=1.3.2.2
     , text                  ^>=1.2.5.0  || ^>=2.0.1    || ^>=2.1
     , time                  ^>=1.11.1.1 || ^>=1.12.2   || ^>=1.13 || ^>=1.14
 

--- a/test/initialise/CabalGolden.hs
+++ b/test/initialise/CabalGolden.hs
@@ -39,6 +39,7 @@ convertTest p = goldenVsStringDiff n diff gold action
     configuration =
       Configuration
         { name = "sentinel",
+          cabalName = "sentinel",
           homepage = fromJust (parseURI "https://github.com/sentinel/sentinel.git"),
           author = "Sentinel",
           maintainer = "sentinel@example.com",

--- a/test/initialise/ConfigurationSpec.hs
+++ b/test/initialise/ConfigurationSpec.hs
@@ -29,22 +29,22 @@ spec =
         parse ["--homepage", "not-a-url"]
           `shouldFailWith` ( strip $
                                unlines
-                                 [ "option --homepage: cannot parse value `not-a-url'",
-                                   "",
-                                   "Usage:  [--name NAME] [--homepage URL] [--author AUTHOR] ",
-                                   "        [--maintainer MAINTAINER] [--licence LICENCE] [--verbosity VERBOSITY]"
-                                 ],
+                                 ( [ "option --homepage: cannot parse value `not-a-url'",
+                                     ""
+                                   ]
+                                     <> usage
+                                 ),
                              ExitFailure 1
                            )
       it "should error if licence isn't an SPDX licence ID" $ do
         parse ["--licence", "not-a-licence"]
           `shouldFailWith` ( strip $
                                unlines
-                                 [ "option --licence: cannot parse value `not-a-licence'",
-                                   "",
-                                   "Usage:  [--name NAME] [--homepage URL] [--author AUTHOR] ",
-                                   "        [--maintainer MAINTAINER] [--licence LICENCE] [--verbosity VERBOSITY]"
-                                 ],
+                                 ( [ "option --licence: cannot parse value `not-a-licence'",
+                                     ""
+                                   ]
+                                     <> usage
+                                 ),
                              ExitFailure 1
                            )
 
@@ -69,3 +69,11 @@ defaults =
       dPath = ".",
       dYear = 1970
     }
+
+-- TODO ask the parser for the usage string.
+usage :: [String]
+usage =
+  [ "Usage:  [--name NAME] [--cabal-name CABAL_NAME] [--homepage URL] ",
+    "        [--author AUTHOR] [--maintainer MAINTAINER] [--licence LICENCE] ",
+    "        [--verbosity VERBOSITY]"
+  ]

--- a/test/initialise/DefaultsSpec.hs
+++ b/test/initialise/DefaultsSpec.hs
@@ -39,6 +39,11 @@ spec = describe "Defaults" $ do
             SUT.dPath = p,
             SUT.dYear = dYear
           }
+  describe "isValidPackageName" $ do
+    it "accepts a valid package name" $
+      SUT.isValidPackageName "sentinel" `shouldBe` True
+    it "rejects an invalid package name" $
+      SUT.isValidPackageName "sentinel.ext" `shouldBe` False
 
 httpOrigin :: SUT.Defaults
 httpOrigin =

--- a/test/initialise/FileGolden.hs
+++ b/test/initialise/FileGolden.hs
@@ -3,6 +3,7 @@
 module FileGolden (golden) where
 
 import Configuration (Configuration (..))
+import Control.Monad.Logger (LogLevel (LevelDebug))
 import Control.Monad.Reader (liftIO)
 import Data.Maybe (fromJust)
 import Data.Text.IO (readFile)
@@ -47,10 +48,12 @@ convertTest p = goldenVsStringDiff n diff gold action
     configuration =
       Configuration
         { name = "sentinel",
+          cabalName = "sentinel",
           homepage = fromJust (parseURI "https://github.com/sentinel/sentinel.git"),
           author = "Sentinel",
           maintainer = "sentinel@example.com",
           licence = MIT,
           path = ".",
-          year = 1970
+          year = 1970,
+          verbosity = LevelDebug
         }

--- a/test/initialise/InitialiseSpec.hs
+++ b/test/initialise/InitialiseSpec.hs
@@ -3,6 +3,7 @@
 module InitialiseSpec (spec) where
 
 import Configuration (Configuration (..))
+import Control.Monad.Logger (LogLevel (LevelDebug))
 import Data.Maybe (fromJust)
 import Data.Text (Text, pack)
 import Distribution.SPDX (LicenseId (MIT))
@@ -21,12 +22,14 @@ spec = describe "Initialisers" $ do
       let configuration =
             Configuration
               { name = "sentinel",
+                cabalName = "sentinel",
                 homepage = fromJust (parseURI "https://github.com/sentinel/sentinel.git"),
                 author = "Sentinel",
                 maintainer = "sentinel@example.com",
                 licence = MIT,
                 path = p,
-                year = 1970
+                year = 1970,
+                verbosity = LevelDebug
               }
 
       SUT.runInitialiser SUT.defaultInitialiser configuration


### PR DESCRIPTION
Cabal names have restrictions that don't apply to general names on repositories. This change ensures we get a proper Cabal name if the default isn't valid.